### PR TITLE
Improve configs

### DIFF
--- a/configs/babel.js
+++ b/configs/babel.js
@@ -1,6 +1,8 @@
+/** @type {import('eslint').ESLint.ConfigData} */
 module.exports = {
   parser: '@babel/eslint-parser',
   parserOptions: {
-    sourceType: 'module'
+    sourceType: 'module',
+    ecmaVersion: 2020
   }
 }

--- a/configs/node.js
+++ b/configs/node.js
@@ -1,10 +1,17 @@
 module.exports = {
-  extends: [
-    'plugin:node/recommended'
-  ],
   plugins: [
     'node'
   ],
+  extends: [
+    'plugin:node/recommended'
+  ],
+  parserOptions: {
+    // node 14+
+    ecmaVersion: 2020
+  },
+  env: {
+    node: true
+  },
   rules: {
     // this doesn't seem to work very well :shrug:
     'node/no-unpublished-require': 0

--- a/configs/recommended.js
+++ b/configs/recommended.js
@@ -6,6 +6,9 @@ module.exports = {
     'plugin:promise/recommended'
   ],
   rules: {
+    // these rules are nice reminders, but not necessarily errors
+    'promise/always-return': 'warn',
+    'promise/catch-or-return': 'warn',
     /**
      * We generally don't need or want semicolons, but we should require them
      * before so-called continuation characters like "(" and "[", because


### PR DESCRIPTION
- For both the `babel` and `node` configs, we now set `parserOptions.ecmaVersion` to `2020`, which (among other things) enables the [optional chaining] and [nullish coalescing] operators
- The `node` config now sets `env.node` to `true` (because duh)
- I've found the [`promise/always-return`](https://github.com/xjamundx/eslint-plugin-promise/blob/development/docs/rules/always-return.md) and [`promise/catch-or-return`](https://github.com/xjamundx/eslint-plugin-promise/blob/development/docs/rules/catch-or-return.md) rules to be difficult to work with, so I'm downgrading their severity to `warn`.

[optional chaining]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining
[nullish coalescing]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator